### PR TITLE
feat: additional metadata properties

### DIFF
--- a/nostr/nostr-base/src/main/java/org/tbk/nostr/base/Metadata.java
+++ b/nostr/nostr-base/src/main/java/org/tbk/nostr/base/Metadata.java
@@ -57,4 +57,7 @@ public class Metadata {
      */
     @Nullable
     String nip05;
+
+    @Nullable
+    String lud16;
 }

--- a/nostr/nostr-base/src/main/java/org/tbk/nostr/base/Metadata.java
+++ b/nostr/nostr-base/src/main/java/org/tbk/nostr/base/Metadata.java
@@ -7,8 +7,9 @@ import javax.annotation.Nullable;
 import java.net.URI;
 
 /**
- * As defined in <a href="https://github.com/nostr-protocol/nips/blob/4f33dbc2b86684f9bf26dd1b0fc9789e3cbf2165/24.md">NIP-1</a>
- * and <a href="https://github.com/nostr-protocol/nips/blob/4f33dbc2b86684f9bf26dd1b0fc9789e3cbf2165/24.md">NIP-24: Extra metadata fields and tags</a>.
+ * As defined in <a href="https://github.com/nostr-protocol/nips/blob/4f33dbc2b86684f9bf26dd1b0fc9789e3cbf2165/01.md">NIP-1</a>,
+ * <a href="https://github.com/nostr-protocol/nips/blob/4f33dbc2b86684f9bf26dd1b0fc9789e3cbf2165/05.md">NIP-05</a> and
+ * <a href="https://github.com/nostr-protocol/nips/blob/4f33dbc2b86684f9bf26dd1b0fc9789e3cbf2165/24.md">NIP-24</a>.
  */
 @Value
 @Builder(builderClassName = "Builder", builderMethodName = "newBuilder")
@@ -42,8 +43,18 @@ public class Metadata {
     URI banner;
 
     /**
-     * A boolean to clarify that the content is entirely or partially the result of automation, such as with chatbots or newsfeeds.
+     * A boolean to clarify that the content is entirely or partially the result of automation, such as with chatbots
+     * or newsfeeds.
      */
     @Nullable
     Boolean bot;
+
+    /**
+     * An <a href="https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1">internet identifier</a>
+     * (an email-like address) as the value. Although there is a link to a very liberal "internet identifier"
+     * specification above, NIP-05 assumes the <local-part> part will be restricted to the characters
+     * <code>a-z0-9-_.</code>, case-insensitive.
+     */
+    @Nullable
+    String nip05;
 }

--- a/nostr/nostr-base/src/main/java/org/tbk/nostr/base/Metadata.java
+++ b/nostr/nostr-base/src/main/java/org/tbk/nostr/base/Metadata.java
@@ -6,6 +6,10 @@ import lombok.Value;
 import javax.annotation.Nullable;
 import java.net.URI;
 
+/**
+ * As defined in <a href="https://github.com/nostr-protocol/nips/blob/4f33dbc2b86684f9bf26dd1b0fc9789e3cbf2165/24.md">NIP-1</a>
+ * and <a href="https://github.com/nostr-protocol/nips/blob/4f33dbc2b86684f9bf26dd1b0fc9789e3cbf2165/24.md">NIP-24: Extra metadata fields and tags</a>.
+ */
 @Value
 @Builder(builderClassName = "Builder", builderMethodName = "newBuilder")
 public class Metadata {
@@ -36,4 +40,10 @@ public class Metadata {
      */
     @Nullable
     URI banner;
+
+    /**
+     * A boolean to clarify that the content is entirely or partially the result of automation, such as with chatbots or newsfeeds.
+     */
+    @Nullable
+    Boolean bot;
 }

--- a/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonReader.java
+++ b/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonReader.java
@@ -1,6 +1,5 @@
 package org.tbk.nostr.proto.json;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.tbk.nostr.base.Metadata;
 import org.tbk.nostr.proto.Event;
 import org.tbk.nostr.proto.Request;

--- a/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonRequestWriter.java
+++ b/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonRequestWriter.java
@@ -48,6 +48,7 @@ final class JsonRequestWriter {
                     .put("banner", Optional.ofNullable(val.getBanner())
                             .map(URI::toString)
                             .orElse(null))
+                    .put("bot", Boolean.TRUE.equals(val.getBot()))
                     .end()
                     .finish();
         } catch (IOException e) {

--- a/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonRequestWriter.java
+++ b/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonRequestWriter.java
@@ -56,6 +56,9 @@ final class JsonRequestWriter {
             if (val.getNip05() != null) {
                 builder.put("nip05", val.getNip05());
             }
+            if (val.getLud16() != null) {
+                builder.put("lud16", val.getLud16());
+            }
             return builder.end().finish();
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonRequestWriter.java
+++ b/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonRequestWriter.java
@@ -2,6 +2,7 @@ package org.tbk.nostr.proto.json;
 
 import com.fasterxml.jackson.jr.ob.JSONComposer;
 import com.fasterxml.jackson.jr.ob.comp.ArrayComposer;
+import com.fasterxml.jackson.jr.ob.comp.ObjectComposer;
 import com.google.common.annotations.VisibleForTesting;
 import org.tbk.nostr.base.Metadata;
 import org.tbk.nostr.proto.*;
@@ -33,7 +34,7 @@ final class JsonRequestWriter {
 
     static String toJson(Metadata val) {
         try {
-            return json
+            ObjectComposer<JSONComposer<String>> builder = json
                     .composeString()
                     .startObject()
                     .put("name", val.getName())
@@ -47,10 +48,15 @@ final class JsonRequestWriter {
                             .orElse(null))
                     .put("banner", Optional.ofNullable(val.getBanner())
                             .map(URI::toString)
-                            .orElse(null))
-                    .put("bot", Boolean.TRUE.equals(val.getBot()))
-                    .end()
-                    .finish();
+                            .orElse(null));
+
+            if (val.getBot() != null) {
+                builder.put("bot", Boolean.TRUE.equals(val.getBot()));
+            }
+            if (val.getNip05() != null) {
+                builder.put("nip05", val.getNip05());
+            }
+            return builder.end().finish();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonResponseReader.java
+++ b/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonResponseReader.java
@@ -155,6 +155,10 @@ final class JsonResponseReader {
                         .map(String::valueOf)
                         .map(URI::create)
                         .orElse(null))
+                .bot(Optional.ofNullable(map.get("bot"))
+                        .map(String::valueOf)
+                        .map(Boolean::parseBoolean)
+                        .orElse(null))
                 .build();
     }
 }

--- a/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonResponseReader.java
+++ b/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonResponseReader.java
@@ -165,6 +165,10 @@ final class JsonResponseReader {
                 .map(String::valueOf)
                 .ifPresent(builder::nip05);
 
+        Optional.ofNullable(map.get("lud16"))
+                .map(String::valueOf)
+                .ifPresent(builder::lud16);
+
         return builder.build();
     }
 }

--- a/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonResponseReader.java
+++ b/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonResponseReader.java
@@ -133,7 +133,7 @@ final class JsonResponseReader {
     }
 
     private static Metadata metadataFromMap(Map<String, Object> map, Metadata.Builder metadata) {
-        return metadata
+        Metadata.Builder builder = metadata
                 .name(Optional.ofNullable(map.get("name"))
                         .map(String::valueOf)
                         .orElse(null))
@@ -154,11 +154,17 @@ final class JsonResponseReader {
                 .banner(Optional.ofNullable(map.get("banner"))
                         .map(String::valueOf)
                         .map(URI::create)
-                        .orElse(null))
-                .bot(Optional.ofNullable(map.get("bot"))
-                        .map(String::valueOf)
-                        .map(Boolean::parseBoolean)
-                        .orElse(null))
-                .build();
+                        .orElse(null));
+
+        Optional.ofNullable(map.get("bot"))
+                .map(String::valueOf)
+                .map(Boolean::parseBoolean)
+                .ifPresent(builder::bot);
+
+        Optional.ofNullable(map.get("nip05"))
+                .map(String::valueOf)
+                .ifPresent(builder::nip05);
+
+        return builder.build();
     }
 }

--- a/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonRequestWriterTest.java
+++ b/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonRequestWriterTest.java
@@ -485,7 +485,8 @@ class JsonRequestWriterTest {
                 .website(URI.create("https://www.example.com/"))
                 .banner(URI.create("https://www.example.com/banner.png"))
                 .bot(true)
-                .nip05("name@example.com")
+                .nip05("nip05@example.com")
+                .lud16("lud16@example.com")
                 .build());
 
         assertThat(JSON.std.anyFrom(json), is(JSON.std.anyFrom("""
@@ -497,7 +498,8 @@ class JsonRequestWriterTest {
                   "website": "https://www.example.com/",
                   "banner": "https://www.example.com/banner.png",
                   "bot": true,
-                  "nip05": "name@example.com"
+                  "nip05": "nip05@example.com",
+                  "lud16": "lud16@example.com"
                 }
                 """)));
     }

--- a/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonRequestWriterTest.java
+++ b/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonRequestWriterTest.java
@@ -470,8 +470,7 @@ class JsonRequestWriterTest {
                   "picture": "https://www.example.com/example.png",
                   "website": null,
                   "banner": null,
-                  "display_name": null,
-                  "bot": false
+                  "display_name": null
                 }
                 """)));
     }
@@ -486,6 +485,7 @@ class JsonRequestWriterTest {
                 .website(URI.create("https://www.example.com/"))
                 .banner(URI.create("https://www.example.com/banner.png"))
                 .bot(true)
+                .nip05("name@example.com")
                 .build());
 
         assertThat(JSON.std.anyFrom(json), is(JSON.std.anyFrom("""
@@ -496,7 +496,8 @@ class JsonRequestWriterTest {
                   "display_name": "display name",
                   "website": "https://www.example.com/",
                   "banner": "https://www.example.com/banner.png",
-                  "bot": true
+                  "bot": true,
+                  "nip05": "name@example.com"
                 }
                 """)));
     }

--- a/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonRequestWriterTest.java
+++ b/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonRequestWriterTest.java
@@ -470,7 +470,8 @@ class JsonRequestWriterTest {
                   "picture": "https://www.example.com/example.png",
                   "website": null,
                   "banner": null,
-                  "display_name": null
+                  "display_name": null,
+                  "bot": false
                 }
                 """)));
     }
@@ -484,6 +485,7 @@ class JsonRequestWriterTest {
                 .displayName("display name")
                 .website(URI.create("https://www.example.com/"))
                 .banner(URI.create("https://www.example.com/banner.png"))
+                .bot(true)
                 .build());
 
         assertThat(JSON.std.anyFrom(json), is(JSON.std.anyFrom("""
@@ -493,7 +495,8 @@ class JsonRequestWriterTest {
                   "picture": "https://www.example.com/picture.png",
                   "display_name": "display name",
                   "website": "https://www.example.com/",
-                  "banner": "https://www.example.com/banner.png"
+                  "banner": "https://www.example.com/banner.png",
+                  "bot": true
                 }
                 """)));
     }

--- a/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonResponseReaderTest.java
+++ b/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonResponseReaderTest.java
@@ -284,7 +284,8 @@ class JsonResponseReaderTest {
                   "picture": "https://www.example.com/picture.png",
                   "display_name": "display name",
                   "website": "https://www.example.com/",
-                  "banner": "https://www.example.com/banner.png"
+                  "banner": "https://www.example.com/banner.png",
+                  "bot": true
                 }
                 """, Metadata.newBuilder());
 
@@ -294,6 +295,7 @@ class JsonResponseReaderTest {
         assertThat(metadata.getDisplayName(), is("display name"));
         assertThat(metadata.getWebsite(), is(URI.create("https://www.example.com/")));
         assertThat(metadata.getBanner(), is(URI.create("https://www.example.com/banner.png")));
+        assertThat(metadata.getBot(), is(Boolean.TRUE));
     }
 
     @Test
@@ -319,7 +321,7 @@ class JsonResponseReaderTest {
         assertThat(metadata1.getDisplayName(), is(nullValue()));
         assertThat(metadata1.getWebsite(), is(nullValue()));
         assertThat(metadata1.getBanner(), is(nullValue()));
-
+        assertThat(metadata1.getBot(), is(nullValue()));
 
         Metadata metadata2 = JsonReader.fromJson("""
                 {
@@ -333,6 +335,7 @@ class JsonResponseReaderTest {
         assertThat(metadata2.getDisplayName(), is(nullValue()));
         assertThat(metadata2.getWebsite(), is(nullValue()));
         assertThat(metadata2.getBanner(), is(nullValue()));
+        assertThat(metadata2.getBot(), is(nullValue()));
 
 
         Metadata metadata3 = JsonReader.fromJson("""
@@ -347,6 +350,7 @@ class JsonResponseReaderTest {
         assertThat(metadata3.getDisplayName(), is(nullValue()));
         assertThat(metadata3.getWebsite(), is(nullValue()));
         assertThat(metadata3.getBanner(), is(nullValue()));
+        assertThat(metadata3.getBot(), is(nullValue()));
     }
 
 

--- a/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonResponseReaderTest.java
+++ b/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonResponseReaderTest.java
@@ -273,6 +273,9 @@ class JsonResponseReaderTest {
         assertThat(metadata.getDisplayName(), is(nullValue()));
         assertThat(metadata.getWebsite(), is(nullValue()));
         assertThat(metadata.getBanner(), is(nullValue()));
+        assertThat(metadata.getBot(), is(nullValue()));
+        assertThat(metadata.getNip05(), is(nullValue()));
+        assertThat(metadata.getLud16(), is(nullValue()));
     }
 
     @Test
@@ -286,7 +289,8 @@ class JsonResponseReaderTest {
                   "website": "https://www.example.com/",
                   "banner": "https://www.example.com/banner.png",
                   "bot": true,
-                  "nip05": "name@example.com"
+                  "nip05": "nip05@example.com",
+                  "lud16": "lud16@example.com"
                 }
                 """, Metadata.newBuilder());
 
@@ -297,7 +301,8 @@ class JsonResponseReaderTest {
         assertThat(metadata.getWebsite(), is(URI.create("https://www.example.com/")));
         assertThat(metadata.getBanner(), is(URI.create("https://www.example.com/banner.png")));
         assertThat(metadata.getBot(), is(Boolean.TRUE));
-        assertThat(metadata.getNip05(), is("name@example.com"));
+        assertThat(metadata.getNip05(), is("nip05@example.com"));
+        assertThat(metadata.getLud16(), is("lud16@example.com"));
     }
 
     @Test
@@ -312,6 +317,7 @@ class JsonResponseReaderTest {
         assertThat(metadata0.getBanner(), is(nullValue()));
         assertThat(metadata0.getBot(), is(nullValue()));
         assertThat(metadata0.getNip05(), is(nullValue()));
+        assertThat(metadata0.getLud16(), is(nullValue()));
 
         Metadata metadata1 = JsonReader.fromJson("""
                 {
@@ -327,6 +333,7 @@ class JsonResponseReaderTest {
         assertThat(metadata1.getBanner(), is(nullValue()));
         assertThat(metadata1.getBot(), is(nullValue()));
         assertThat(metadata1.getNip05(), is(nullValue()));
+        assertThat(metadata1.getLud16(), is(nullValue()));
 
         Metadata metadata2 = JsonReader.fromJson("""
                 {
@@ -342,6 +349,7 @@ class JsonResponseReaderTest {
         assertThat(metadata2.getBanner(), is(nullValue()));
         assertThat(metadata2.getBot(), is(nullValue()));
         assertThat(metadata2.getNip05(), is(nullValue()));
+        assertThat(metadata2.getLud16(), is(nullValue()));
 
 
         Metadata metadata3 = JsonReader.fromJson("""
@@ -358,6 +366,7 @@ class JsonResponseReaderTest {
         assertThat(metadata3.getBanner(), is(nullValue()));
         assertThat(metadata3.getBot(), is(nullValue()));
         assertThat(metadata3.getNip05(), is(nullValue()));
+        assertThat(metadata3.getLud16(), is(nullValue()));
     }
 
     @Test
@@ -385,6 +394,7 @@ class JsonResponseReaderTest {
         assertThat(metadata.getBanner(), is(URI.create("https://cdn.nostr.build/i/0aeb7560c271bbb1cef00760989acd9dd3f37bdc42b37852eecb0d0b70a3e862.jpg")));
         assertThat(metadata.getBot(), is(nullValue()));
         assertThat(metadata.getNip05(), is("_@dergigi.com"));
+        assertThat(metadata.getLud16(), is("dergigi@primal.net"));
     }
 
     @Test

--- a/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonResponseReaderTest.java
+++ b/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonResponseReaderTest.java
@@ -285,7 +285,8 @@ class JsonResponseReaderTest {
                   "display_name": "display name",
                   "website": "https://www.example.com/",
                   "banner": "https://www.example.com/banner.png",
-                  "bot": true
+                  "bot": true,
+                  "nip05": "name@example.com"
                 }
                 """, Metadata.newBuilder());
 
@@ -296,6 +297,7 @@ class JsonResponseReaderTest {
         assertThat(metadata.getWebsite(), is(URI.create("https://www.example.com/")));
         assertThat(metadata.getBanner(), is(URI.create("https://www.example.com/banner.png")));
         assertThat(metadata.getBot(), is(Boolean.TRUE));
+        assertThat(metadata.getNip05(), is("name@example.com"));
     }
 
     @Test
@@ -308,6 +310,8 @@ class JsonResponseReaderTest {
         assertThat(metadata0.getDisplayName(), is(nullValue()));
         assertThat(metadata0.getWebsite(), is(nullValue()));
         assertThat(metadata0.getBanner(), is(nullValue()));
+        assertThat(metadata0.getBot(), is(nullValue()));
+        assertThat(metadata0.getNip05(), is(nullValue()));
 
         Metadata metadata1 = JsonReader.fromJson("""
                 {
@@ -322,6 +326,7 @@ class JsonResponseReaderTest {
         assertThat(metadata1.getWebsite(), is(nullValue()));
         assertThat(metadata1.getBanner(), is(nullValue()));
         assertThat(metadata1.getBot(), is(nullValue()));
+        assertThat(metadata1.getNip05(), is(nullValue()));
 
         Metadata metadata2 = JsonReader.fromJson("""
                 {
@@ -336,6 +341,7 @@ class JsonResponseReaderTest {
         assertThat(metadata2.getWebsite(), is(nullValue()));
         assertThat(metadata2.getBanner(), is(nullValue()));
         assertThat(metadata2.getBot(), is(nullValue()));
+        assertThat(metadata2.getNip05(), is(nullValue()));
 
 
         Metadata metadata3 = JsonReader.fromJson("""
@@ -351,8 +357,35 @@ class JsonResponseReaderTest {
         assertThat(metadata3.getWebsite(), is(nullValue()));
         assertThat(metadata3.getBanner(), is(nullValue()));
         assertThat(metadata3.getBot(), is(nullValue()));
+        assertThat(metadata3.getNip05(), is(nullValue()));
     }
 
+    @Test
+    void itShouldParseMetadata3() {
+        String json = """
+                {
+                  "id":"5bbb27cf3c5079cea00b1a4f5943f5790d7ed855fc4f3700514d58976574240b",
+                  "pubkey":"6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93",
+                  "created_at":1714851835,
+                  "kind":0,
+                  "tags":[["alt","User profile for Gigi"]],
+                  "content":"{\\"name\\":\\"Gigi\\",\\"nip05\\":\\"_@dergigi.com\\",\\"about\\":\\"not doing DMs â¢ not writing 21waysbook.com â¢ helping opensats.org â¢ painting twentyone.world â¢ maintaining bitcoin-resources.com & nostr-resources.com â¢ starting toomanyprojects.xyz ð¥\\",\\"lud16\\":\\"dergigi@primal.net\\",\\"display_name\\":\\"Gigi\\",\\"picture\\":\\"https://dergigi.com/assets/images/avatars/07.png\\",\\"banner\\":\\"https://cdn.nostr.build/i/0aeb7560c271bbb1cef00760989acd9dd3f37bdc42b37852eecb0d0b70a3e862.jpg\\",\\"website\\":\\"https://dergigi.com\\"}",
+                  "sig":"a773117b6d866198474655559c44af86cedc230faac589e45399551151ad1125a94701c3008f32444ce332db647eddfd71a2c963f9ad88597cac98ebeaee304b"
+                }
+                """;
+
+        Event event = JsonReader.fromJson(json, Event.newBuilder());
+
+        Metadata metadata = JsonReader.fromJson(event.getContent(), Metadata.newBuilder());
+        assertThat(metadata.getName(), is("Gigi"));
+        assertThat(metadata.getAbout(), is(startsWith("not")));
+        assertThat(metadata.getPicture(), is(URI.create("https://dergigi.com/assets/images/avatars/07.png")));
+        assertThat(metadata.getDisplayName(), is("Gigi"));
+        assertThat(metadata.getWebsite(), is(URI.create("https://dergigi.com")));
+        assertThat(metadata.getBanner(), is(URI.create("https://cdn.nostr.build/i/0aeb7560c271bbb1cef00760989acd9dd3f37bdc42b37852eecb0d0b70a3e862.jpg")));
+        assertThat(metadata.getBot(), is(nullValue()));
+        assertThat(metadata.getNip05(), is("_@dergigi.com"));
+    }
 
     @Test
     void itShouldParseMetadata3FailOnInvalidPictureUri() {


### PR DESCRIPTION
Partly addresses #27 

Adds following properties to metadata (kind `0`) content:
- `bot`
- `nip05`
- `lud16`