### PR TITLE
feat(nip42): add auth request/response

### DIFF
--- a/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonRequestReader.java
+++ b/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonRequestReader.java
@@ -89,6 +89,18 @@ final class JsonRequestReader {
                                         .build())
                                 .build();
                     }
+                    case AUTH -> {
+                        if (array.length < 2) {
+                            throw new IllegalArgumentException("Could not parse passed arg");
+                        }
+
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> eventMap = (Map<String, Object>) array[1];
+                        yield request.setAuth(AuthRequest.newBuilder()
+                                        .setEvent(Json.fromMap(eventMap, Event.newBuilder()))
+                                        .build())
+                                .build();
+                    }
                     case KIND_NOT_SET -> throw new IllegalArgumentException("Kind not set");
                 };
             } else {

--- a/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonRequestWriter.java
+++ b/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonRequestWriter.java
@@ -24,11 +24,12 @@ final class JsonRequestWriter {
 
     static String toJson(Request val) {
         return switch (val.getKindCase()) {
-            case Request.KindCase.EVENT -> toJson(val.getEvent());
-            case Request.KindCase.REQ -> toJson(val.getReq());
-            case Request.KindCase.CLOSE -> toJson(val.getClose());
-            case Request.KindCase.COUNT -> toJson(val.getCount());
-            case Request.KindCase.KIND_NOT_SET -> throw new IllegalArgumentException("Kind not set");
+            case EVENT -> toJson(val.getEvent());
+            case REQ -> toJson(val.getReq());
+            case CLOSE -> toJson(val.getClose());
+            case COUNT -> toJson(val.getCount());
+            case AUTH -> toJson(val.getAuth());
+            case KIND_NOT_SET -> throw new IllegalArgumentException("Kind not set");
         };
     }
 
@@ -111,17 +112,11 @@ final class JsonRequestWriter {
     }
 
     private static String toJson(EventRequest val) {
-        try {
-            return json
-                    .composeString()
-                    .startArray()
-                    .add("EVENT")
-                    .addObject(Json.asMap(val.getEvent()))
-                    .end()
-                    .finish();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        return toJsonWithEvent("EVENT", val.getEvent());
+    }
+
+    private static String toJson(AuthRequest val) {
+        return toJsonWithEvent("AUTH", val.getEvent());
     }
 
     private static String toJson(ReqRequest val) {
@@ -130,6 +125,20 @@ final class JsonRequestWriter {
 
     private static String toJson(CountRequest val) {
         return toJsonWithSubscriptionIdAndFilter("COUNT", val.getId(), val.getFiltersList());
+    }
+
+    private static String toJsonWithEvent(String cmd, Event event) {
+        try {
+            return json
+                    .composeString()
+                    .startArray()
+                    .add(cmd)
+                    .addObject(Json.asMap(event))
+                    .end()
+                    .finish();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static String toJsonWithSubscriptionIdAndFilter(String cmd, String subscriptionId, List<Filter> filters) {

--- a/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonResponseReader.java
+++ b/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonResponseReader.java
@@ -107,6 +107,16 @@ final class JsonResponseReader {
                                         .build())
                                 .build();
                     }
+                    case AUTH -> {
+                        if (array.length < 2) {
+                            throw new IllegalArgumentException("Could not parse passed arg");
+                        }
+                        String challenge = String.valueOf(array[1]);
+                        yield response.setAuth(AuthResponse.newBuilder()
+                                        .setChallenge(challenge)
+                                        .build())
+                                .build();
+                    }
                     case KIND_NOT_SET -> throw new IllegalArgumentException("Kind not set");
                 };
             } else {

--- a/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonResponseWriter.java
+++ b/nostr/nostr-proto-json/src/main/java/org/tbk/nostr/proto/json/JsonResponseWriter.java
@@ -21,7 +21,8 @@ final class JsonResponseWriter {
             case CLOSED -> toJson(val.getClosed());
             case NOTICE -> toJson(val.getNotice());
             case COUNT -> toJson(val.getCount());
-            case Response.KindCase.KIND_NOT_SET -> throw new IllegalArgumentException("Kind not set");
+            case AUTH -> toJson(val.getAuth());
+            case KIND_NOT_SET -> throw new IllegalArgumentException("Kind not set");
         };
     }
 
@@ -84,5 +85,9 @@ final class JsonResponseWriter {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static String toJson(AuthResponse val) {
+        return Json.toJsonArray(json, "AUTH", val.getChallenge());
     }
 }

--- a/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonRequestReaderTest.java
+++ b/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonRequestReaderTest.java
@@ -342,4 +342,37 @@ class JsonRequestReaderTest {
                         .build())
                 .build()));
     }
+
+    @Test
+    void itShouldReadAuthRequest0() {
+        Request request = JsonRequestReader.fromJson("""
+                [
+                  "AUTH",
+                  {
+                    "id": "54510202f7e5bae8726048933a1d9833c0b865b5a306d311ed7f572a2bb66ba2",
+                    "pubkey": "493557ea5445d54298010d895d964e286c5d8fd704ac03823c6ddb0317643cef",
+                    "created_at" : 1,
+                    "kind": 22242,
+                    "tags": [
+                      ["relay", "wss://relay.example.com/"],
+                      ["challenge", "challengestringhere"]
+                    ],
+                    "content": "",
+                    "sig": ""
+                  }
+                ]
+                """, Request.newBuilder());
+
+        assertThat(request.getKindCase(), is(Request.KindCase.AUTH));
+        assertThat(request.getAuth(), is(AuthRequest.newBuilder()
+                .setEvent(MoreEvents.withEventId(Event.newBuilder()
+                                .setCreatedAt(1)
+                                .setPubkey(ByteString.fromHex(testSigner.getPublicKey().value.toHex()))
+                                .setKind(22_242)
+                                .addTags(MoreTags.named("relay", "wss://relay.example.com/"))
+                                .addTags(MoreTags.named("challenge", "challengestringhere"))
+                        )
+                        .build())
+                .build()));
+    }
 }

--- a/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonRequestWriterTest.java
+++ b/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonRequestWriterTest.java
@@ -271,6 +271,40 @@ class JsonRequestWriterTest {
     }
 
     @Test
+    void itShouldWriteAuthRequest0() throws IOException {
+        String json = JsonRequestWriter.toJson(Request.newBuilder()
+                .setAuth(AuthRequest.newBuilder()
+                        .setEvent(MoreEvents.withEventId(Event.newBuilder()
+                                        .setCreatedAt(1)
+                                        .setPubkey(ByteString.fromHex(testSigner.getPublicKey().value.toHex()))
+                                        .setKind(22_242)
+                                        .addTags(MoreTags.named("relay", "wss://relay.example.com/"))
+                                        .addTags(MoreTags.named("challenge", "challengestringhere"))
+                                )
+                                .build())
+                        .build())
+                .build());
+
+        assertThat(JSON.std.anyFrom(json), is(JSON.std.anyFrom("""
+                [
+                  "AUTH",
+                  {
+                    "id": "54510202f7e5bae8726048933a1d9833c0b865b5a306d311ed7f572a2bb66ba2",
+                    "pubkey": "493557ea5445d54298010d895d964e286c5d8fd704ac03823c6ddb0317643cef",
+                    "created_at" : 1,
+                    "kind": 22242,
+                    "tags": [
+                      ["relay", "wss://relay.example.com/"],
+                      ["challenge", "challengestringhere"]
+                    ],
+                    "content": "",
+                    "sig": ""
+                  }
+                ]
+                """)));
+    }
+
+    @Test
     void itShouldWriteEvent0() throws IOException {
         String json = JsonRequestWriter.toJson(MoreEvents.withEventId(Event.newBuilder()
                         .setCreatedAt(1)

--- a/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonResponseReaderTest.java
+++ b/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonResponseReaderTest.java
@@ -258,6 +258,22 @@ class JsonResponseReaderTest {
     }
 
     @Test
+    void itShouldParseAuthResponse0() {
+        Response res = JsonReader.fromJson("""
+                [
+                  "AUTH",
+                  "challenge"
+                ]
+                """, Response.newBuilder());
+
+        assertThat(res.getKindCase(), is(Response.KindCase.AUTH));
+        assertThat(res.getAuth(), is(notNullValue()));
+
+        AuthResponse auth = res.getAuth();
+        assertThat(auth.getChallenge(), is("challenge"));
+    }
+
+    @Test
     void itShouldParseMetadata0() {
         Metadata metadata = JsonReader.fromJson("""
                 {

--- a/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonResponseWriterTest.java
+++ b/nostr/nostr-proto-json/src/test/java/org/tbk/nostr/proto/json/JsonResponseWriterTest.java
@@ -191,4 +191,20 @@ class JsonResponseWriterTest {
                 ]
                 """)));
     }
+
+    @Test
+    void itShouldWriteAuthResponse0() throws IOException {
+        String json = JsonWriter.toJson(Response.newBuilder()
+                .setAuth(AuthResponse.newBuilder()
+                        .setChallenge("challenge")
+                        .build())
+                .build());
+
+        assertThat(JSON.std.anyFrom(json), is(JSON.std.anyFrom("""
+                [
+                  "AUTH",
+                  "challenge"
+                ]
+                """)));
+    }
 }

--- a/nostr/nostr-proto/src/main/proto/event.proto
+++ b/nostr/nostr-proto/src/main/proto/event.proto
@@ -43,6 +43,7 @@ message Request {
     ReqRequest req = 2 [json_name = "req"];
     CloseRequest close = 3 [json_name = "close"];
     CountRequest count = 4 [json_name = "count"];
+    AuthRequest auth = 5 [json_name = "auth"];
   }
 }
 
@@ -66,6 +67,12 @@ message CloseRequest {
 message CountRequest {
   string id = 1 [json_name = "id"];
   repeated Filter filters = 2 [json_name = "filters"];
+}
+
+// `auth` from NIP-42: https://github.com/nostr-protocol/nips/blob/master/42.md
+// ["AUTH", <signed-event-json>]
+message AuthRequest {
+  Event event = 1 [json_name = "event"];
 }
 
 /*{
@@ -105,6 +112,7 @@ message TagFilter {
 ["EOSE", <subscription_id>], used to indicate the end of stored events and the beginning of events newly received in real-time.
 ["CLOSED", <subscription_id>, <message>], used to indicate that a subscription was ended on the server side.
 ["NOTICE", <message>]
+["AUTH", <challenge-string>]
  */
 message Response {
   oneof kind {
@@ -114,6 +122,7 @@ message Response {
     ClosedResponse closed = 4 [json_name = "closed"];
     NoticeResponse notice = 5 [json_name = "notice"];
     CountResponse count = 6 [json_name = "count"];
+    AuthResponse auth = 7 [json_name = "auth"];
   }
 }
 
@@ -149,4 +158,9 @@ message CountResponse {
 message CountResult {
   uint64 count = 1 [json_name = "count"];
   bool approximate = 2 [json_name = "approximate"];
+}
+
+// `auth` from NIP-42: https://github.com/nostr-protocol/nips/blob/master/42.md
+message AuthResponse {
+  string challenge = 1 [json_name = "challenge"];
 }


### PR DESCRIPTION
Partly addresses #21.

This adds message type `AUTH`.
Does not include any helper or relay related code–this will be added in a follow-up PR.