### PR TITLE
example(shell): ability to derive specific persona account

### DIFF
--- a/examples/nostr-shell-example-application/src/integTest/java/org/tbk/nostr/example/shell/command/PersonaCommandTest.java
+++ b/examples/nostr-shell-example-application/src/integTest/java/org/tbk/nostr/example/shell/command/PersonaCommandTest.java
@@ -51,6 +51,37 @@ class PersonaCommandTest {
     }
 
     @Test
+    void testPersonaAlice15() {
+        ShellTestClient.InteractiveShellSession session = client
+                .interactive()
+                .run();
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+            ShellAssertions.assertThat(session.screen())
+                    .containsText("nostr:>");
+        });
+
+        session.write(session.writeSequence()
+                .text("persona").space()
+                .text("--name").space().text("alice").space()
+                .text("--account").space().text("15").space()
+                .carriageReturn()
+                .build());
+
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            ShellAssertions.assertThat(session.screen())
+                    .containsText("{")
+                    .containsText("\"entropy\" : \"2bd806c97f0e00af1a1fc3328fa763a9\"")
+                    .containsText("\"mnemonic\" : \"cloth scan rather wrap theme fiscal half wear crater large suggest fancy\"")
+                    .containsText("\"privateKey\" : \"223955cda115e533305bc7bb27d598cd807238da2418be3b882450fc812f41e7\"")
+                    .containsText("\"publicKey\" : \"19f322cf03fb653f1bcc7b736d1ea4b6cdf100accec83f4282433010b7ef09b5\"")
+                    .containsText("\"nsec\" : \"nsec1ygu4tndpzhjnxvzmc7aj04vcekq8ywx6ysvtuwugy3g0eqf0g8nse3k7qa\"")
+                    .containsText("\"npub\" : \"npub1r8ej9ncrldjn7x7v0dek684ykmxlzq9vemyr7s5zgvcppdl0px6srjpt4a\"")
+                    .containsText("}");
+        });
+    }
+
+    @Test
     void testPersonaBob0() {
         ShellTestClient.InteractiveShellSession session = client
                 .interactive()
@@ -76,6 +107,37 @@ class PersonaCommandTest {
                     .containsText("\"publicKey\" : \"72603b8a1329cd9cb7e117f1d9d6ae6bb9385ec591d30a3c91ef40aa8aa4c409\"")
                     .containsText("\"nsec\" : \"nsec1mdf536ez4wcz8l0xq9d9v2jk5zw6dm3ytrrhzn95tzhc6azpum3s9xd9wz\"")
                     .containsText("\"npub\" : \"npub1wfsrhzsn98xeedlpzlcan44wdwunshk9j8fs50y3aaq24z4ycsysuspqy8\"")
+                    .containsText("}");
+        });
+    }
+
+    @Test
+    void testPersonaBob15() {
+        ShellTestClient.InteractiveShellSession session = client
+                .interactive()
+                .run();
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+            ShellAssertions.assertThat(session.screen())
+                    .containsText("nostr:>");
+        });
+
+        session.write(session.writeSequence()
+                .text("persona").space()
+                .text("--name").space().text("bob").space()
+                .text("--account").space().text("15").space()
+                .carriageReturn()
+                .build());
+
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            ShellAssertions.assertThat(session.screen())
+                    .containsText("{")
+                    .containsText("\"entropy\" : \"81b637d8fcd2c6da6359e6963113a117\"")
+                    .containsText("\"mnemonic\" : \"like random wage whale cluster honey miracle devote normal mass tribe comfort\"")
+                    .containsText("\"privateKey\" : \"415cdb8c2c397802cde2ea9ec6173379f81e56bf04777d6daea75a93a7dadc1d\"")
+                    .containsText("\"publicKey\" : \"7705f65a3c1a062d762aaf0af656407ea97a86e343cc31829eebaaa905e5da7d\"")
+                    .containsText("\"nsec\" : \"nsec1g9wdhrpv89uq9n0za20vv9en08upu44lq3mh6mdw5adf8f76msws3pzj7t\"")
+                    .containsText("\"npub\" : \"npub1wuzlvk3urgrz6a324u90v4jq065h4phrg0xrrq57aw42jp09mf7ss5xcqq\"")
                     .containsText("}");
         });
     }

--- a/examples/nostr-shell-example-application/src/main/java/org/tbk/nostr/example/shell/command/PersonaCommand.java
+++ b/examples/nostr-shell-example-application/src/main/java/org/tbk/nostr/example/shell/command/PersonaCommand.java
@@ -27,13 +27,16 @@ class PersonaCommand {
 
     @ShellMethod(key = "persona", value = "Generate nostr personas")
     public String run(
-            @ShellOption(value = "name", help = "persona name (used to derive master key)") String name
+            @ShellOption(value = "name", help = "persona name (used to derive master key)") String name,
+            @ShellOption(value = "account", defaultValue = "0", help = "identity account index (default: 0)") long accountIndexArg
     ) throws IOException {
+        long accountIndex = accountIndexArg >= 0 ? accountIndexArg : 0;
+
         byte[] entropy = Arrays.copyOfRange(Crypto.sha256(name.getBytes(StandardCharsets.UTF_8)), 0, 16);
 
         List<String> mnemonics = MnemonicCode.toMnemonics(entropy);
 
-        PrivateKey privateKey = MoreIdentities.fromMnemonic(mnemonics);
+        PrivateKey privateKey = MoreIdentities.fromMnemonic(mnemonics, accountIndex);
 
         return Json.jsonPretty.composeString()
                 .startObject()

--- a/nostr/nostr-identity/src/main/java/org/tbk/nostr/identity/MoreIdentities.java
+++ b/nostr/nostr-identity/src/main/java/org/tbk/nostr/identity/MoreIdentities.java
@@ -30,7 +30,10 @@ public final class MoreIdentities {
     }
 
     public static PrivateKey fromSeed(byte[] seed) {
-        return Nip6.fromSeed(seed);
+        return fromSeed(seed, 0L);
+    }
+    public static PrivateKey fromSeed(byte[] seed, long accountIndex) {
+        return Nip6.fromSeed(seed, accountIndex);
     }
 
     public static PrivateKey fromMnemonic(String mnemonic) {
@@ -38,7 +41,15 @@ public final class MoreIdentities {
     }
 
     public static PrivateKey fromMnemonic(String mnemonic, String passphrase) {
-        return fromSeed(MnemonicCode.toSeed(mnemonic, passphrase));
+        return fromMnemonic(mnemonic, passphrase, 0L);
+    }
+
+    public static PrivateKey fromMnemonic(String mnemonic, long accountIndex) {
+        return fromMnemonic(mnemonic, "", accountIndex);
+    }
+
+    public static PrivateKey fromMnemonic(String mnemonic, String passphrase, long accountIndex) {
+        return fromSeed(MnemonicCode.toSeed(mnemonic, passphrase), accountIndex);
     }
 
     public static PrivateKey fromMnemonic(List<String> mnemonic) {
@@ -46,6 +57,14 @@ public final class MoreIdentities {
     }
 
     public static PrivateKey fromMnemonic(List<String> mnemonic, String passphrase) {
-        return fromSeed(MnemonicCode.toSeed(mnemonic, passphrase));
+        return fromMnemonic(mnemonic, passphrase, 0L);
+    }
+
+    public static PrivateKey fromMnemonic(List<String> mnemonic, long accountIndex) {
+        return fromMnemonic(mnemonic, "", accountIndex);
+    }
+
+    public static PrivateKey fromMnemonic(List<String> mnemonic, String passphrase, long accountIndex) {
+        return fromMnemonic(String.join(" ", mnemonic), passphrase, accountIndex);
     }
 }


### PR DESCRIPTION
ability to derive specific persona account.
e.g.
##### Build
```shell
./gradlew -p examples/nostr-shell-example-application clean bootJar
```
##### Run
```shell
./examples/nostr-shell-example-application/build/libs/nostr-shell-example-application-${version}-boot.jar 
```
```shell
nostr:>persona --name alice --account 15
{
  "entropy" : "2bd806c97f0e00af1a1fc3328fa763a9",
  "mnemonic" : "cloth scan rather wrap theme fiscal half wear crater large suggest fancy",
  "privateKey" : "223955cda115e533305bc7bb27d598cd807238da2418be3b882450fc812f41e7",
  "publicKey" : "19f322cf03fb653f1bcc7b736d1ea4b6cdf100accec83f4282433010b7ef09b5",
  "nsec" : "nsec1ygu4tndpzhjnxvzmc7aj04vcekq8ywx6ysvtuwugy3g0eqf0g8nse3k7qa",
  "npub" : "npub1r8ej9ncrldjn7x7v0dek684ykmxlzq9vemyr7s5zgvcppdl0px6srjpt4a"
}

```