### PR TITLE
example(shell): identity-vanity command with npub suffix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- upgrade: update spring-shell from v3.3.3 to v3.4.0
+
 ## [0.2.0] - 2025-01-24
 ### Breaking
 - MoreEvents: rename method `eventId` to `calculateEventId`

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- upgrade: update spring-boot from v3.4.0 to v3.4.2
 - upgrade: update spring-shell from v3.3.3 to v3.4.0
 
 ## [0.2.0] - 2025-01-24

--- a/examples/nostr-shell-example-application/build.gradle
+++ b/examples/nostr-shell-example-application/build.gradle
@@ -24,6 +24,9 @@ dependencies {
 
     implementation 'io.projectreactor:reactor-core'
 
+    // for importing "DurationStyle" class
+    implementation 'org.springframework.boot:spring-boot'
+
     implementation 'org.springframework.shell:spring-shell-starter'
     testImplementation 'org.springframework.shell:spring-shell-starter-test'
 }

--- a/examples/nostr-shell-example-application/readme.md
+++ b/examples/nostr-shell-example-application/readme.md
@@ -85,7 +85,6 @@ nostr:>pow --target 25 --json "{ \"kind\": 1, \"content\":\"GM!\", \"tags\": [[ 
 {"id":"00000009af73d28a49db7f6047229cca1da09a46180b46129f2ca5a0a1f43a07","pubkey":"","created_at":1710368995,"kind":1,"tags":[["expiration","1710378232"],["nonce","189309","25"]],"content":"GM!","sig":""}
 ```
 
-
 ### Non-interactive
 ```shell
 ./examples/nostr-shell-example-application/build/libs/nostr-shell-example-application-0.1.0-dev-boot.jar pow --target 25 --parallelism 8 --json '{ \"kind\": 1, \"content\":\"GM!\", \"tags\": [[ \"expiration\", \"1710378232\" ]] }'

--- a/examples/nostr-shell-example-application/src/integTest/java/org/tbk/nostr/example/shell/command/IdentityVanityCommandTest.java
+++ b/examples/nostr-shell-example-application/src/integTest/java/org/tbk/nostr/example/shell/command/IdentityVanityCommandTest.java
@@ -27,8 +27,7 @@ class IdentityVanityCommandTest {
                 .run();
 
         await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
-            ShellAssertions.assertThat(session.screen())
-                    .containsText("nostr:>");
+            ShellAssertions.assertThat(session.screen()).containsText("nostr:>");
         });
 
         String npubPrefix = "z";
@@ -57,8 +56,7 @@ class IdentityVanityCommandTest {
                 .run();
 
         await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
-            ShellAssertions.assertThat(session.screen())
-                    .containsText("nostr:>");
+            ShellAssertions.assertThat(session.screen()).containsText("nostr:>");
         });
 
         String npubSuffix = "z";
@@ -87,8 +85,7 @@ class IdentityVanityCommandTest {
                 .run();
 
         await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
-            ShellAssertions.assertThat(session.screen())
-                    .containsText("nostr:>");
+            ShellAssertions.assertThat(session.screen()).containsText("nostr:>");
         });
 
         String prefixAndSuffix = "z";

--- a/examples/nostr-shell-example-application/src/integTest/java/org/tbk/nostr/example/shell/command/IdentityVanityCommandTest.java
+++ b/examples/nostr-shell-example-application/src/integTest/java/org/tbk/nostr/example/shell/command/IdentityVanityCommandTest.java
@@ -21,7 +21,7 @@ class IdentityVanityCommandTest {
     private ShellTestClient client;
 
     @Test
-    void testIdentityVanityInteractive() {
+    void testIdentityVanityPrefix() {
         ShellTestClient.InteractiveShellSession session = client
                 .interactive()
                 .run();
@@ -42,10 +42,71 @@ class IdentityVanityCommandTest {
         await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
             ShellAssertions.assertThat(session.screen())
                     .containsText("{")
+                    .containsText("\"npub\" : \"npub1" + npubPrefix)
+                    .containsText("\"nsec\" : \"nsec1")
                     .containsText("\"privateKey\" : \"")
                     .containsText("\"publicKey\" : \"")
+                    .containsText("}");
+        });
+    }
+
+    @Test
+    void testIdentityVanitySuffix() {
+        ShellTestClient.InteractiveShellSession session = client
+                .interactive()
+                .run();
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+            ShellAssertions.assertThat(session.screen())
+                    .containsText("nostr:>");
+        });
+
+        String npubSuffix = "z";
+
+        session.write(session.writeSequence()
+                .text("identity-vanity").space()
+                .text("--npub-suffix").space().text(npubSuffix).space()
+                .carriageReturn()
+                .build());
+
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+            ShellAssertions.assertThat(session.screen())
+                    .containsText("{")
+                    .containsText("\"npub\" : \"npub1").containsText(npubSuffix + "\"")
                     .containsText("\"nsec\" : \"nsec1")
-                    .containsText("\"npub\" : \"npub1" + npubPrefix)
+                    .containsText("\"privateKey\" : \"")
+                    .containsText("\"publicKey\" : \"")
+                    .containsText("}");
+        });
+    }
+
+    @Test
+    void testIdentityVanityPrefixAndSuffix() {
+        ShellTestClient.InteractiveShellSession session = client
+                .interactive()
+                .run();
+
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+            ShellAssertions.assertThat(session.screen())
+                    .containsText("nostr:>");
+        });
+
+        String prefixAndSuffix = "z";
+
+        session.write(session.writeSequence()
+                .text("identity-vanity").space()
+                .text("--npub-prefix").space().text(prefixAndSuffix).space()
+                .text("--npub-suffix").space().text(prefixAndSuffix).space()
+                .carriageReturn()
+                .build());
+
+        await().atMost(10 * 2, TimeUnit.SECONDS).untilAsserted(() -> {
+            ShellAssertions.assertThat(session.screen())
+                    .containsText("{")
+                    .containsText("\"npub\" : \"npub1" + prefixAndSuffix).containsText(prefixAndSuffix + "\"")
+                    .containsText("\"nsec\" : \"nsec1")
+                    .containsText("\"privateKey\" : \"")
+                    .containsText("\"publicKey\" : \"")
                     .containsText("}");
         });
     }

--- a/examples/nostr-shell-example-application/src/main/java/org/tbk/nostr/example/shell/command/IdentityVanityCommand.java
+++ b/examples/nostr-shell-example-application/src/main/java/org/tbk/nostr/example/shell/command/IdentityVanityCommand.java
@@ -1,6 +1,5 @@
 package org.tbk.nostr.example.shell.command;
 
-import com.google.common.base.Predicate;
 import com.google.common.base.Stopwatch;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +15,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import java.io.IOException;
+import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
 import static java.util.Objects.requireNonNull;
@@ -29,20 +29,26 @@ class IdentityVanityCommand {
     @ShellMethod(key = "identity-vanity", value = "Generate a vanity nostr key pair")
     public String run(
             @ShellOption(value = "npub-prefix", defaultValue = "", help = "npub prefix") String npubPrefixArg,
+            @ShellOption(value = "npub-suffix", defaultValue = "", help = "npub suffix") String npubSuffixArg,
             @ShellOption(value = "parallelism", defaultValue = "0", help = "parallelism level (default: # of processors / 2)") int parallelismArg
     ) throws IOException {
         int parallelism = parallelismArg > 0 ? parallelismArg : Math.max(1, Runtime.getRuntime().availableProcessors() / 2);
         String npubPrefix = npubPrefixArg == null ? "" : npubPrefixArg;
+        String npubSuffix = npubSuffixArg == null ? "" : npubSuffixArg;
 
         if (!hasValidBech32Chars().test(npubPrefix)) {
             throw new IllegalArgumentException("npub-prefix contains invalid bech32 chars");
         }
+        if (!hasValidBech32Chars().test(npubSuffix)) {
+            throw new IllegalArgumentException("npub-suffix contains invalid bech32 chars");
+        }
 
-        log.debug("Starting identity-vanity (npub-prefix := {}, parallelism := {}", npubPrefix, parallelism);
+        log.debug("Starting identity-vanity (npub-prefix := {}, npub-suffix := {}, parallelism := {}", npubPrefix, npubSuffix, parallelism);
 
         Stopwatch stopwatch = Stopwatch.createStarted();
 
-        Identity.Account account = requireNonNull(randomAccountWithNpubHavingPrefix(npubPrefix, parallelism).block());
+        Mono<Identity.Account> accountMono = mineAccountMatching(parallelism, withNpubPrefixAndSuffix(npubPrefix, npubSuffix));
+        Identity.Account account = requireNonNull(accountMono.block());
 
         log.debug("identity-vanity with npub-prefix '{}' took {}", npubPrefix, stopwatch.stop());
 
@@ -59,17 +65,19 @@ class IdentityVanityCommand {
     private static Predicate<String> hasValidBech32Chars() {
         // from https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
         return test -> !test.contains("1") &&
-               !test.contains("b") &&
-               !test.contains("i") &&
-               !test.contains("o");
+                       !test.contains("b") &&
+                       !test.contains("i") &&
+                       !test.contains("o");
     }
 
-    private static Predicate<Identity.Account> withNpubPrefix(String npubPrefix) {
-        return account -> Nip19.encodeNpub(account.getPublicKey()).startsWith("npub1" + npubPrefix);
+    private static Predicate<Identity.Account> withNpubPrefixAndSuffix(String prefix, String suffix) {
+        Predicate<String> prefixPredicate = npub -> npub.startsWith("npub1" + prefix);
+        Predicate<String> suffixPredicate = npub -> npub.endsWith(suffix);
+        return withNpubMatching(prefix.isEmpty() ? suffixPredicate : prefixPredicate.and(suffixPredicate));
     }
 
-    private Mono<Identity.Account> randomAccountWithNpubHavingPrefix(String npubPrefix, int parallelism) {
-        return mineAccountMatching(parallelism, withNpubPrefix(npubPrefix));
+    private static Predicate<Identity.Account> withNpubMatching(Predicate<String> matcher) {
+        return account -> matcher.test(Nip19.encodeNpub(account.getPublicKey()));
     }
 
     private Mono<Identity.Account> mineAccountMatching(int parallelism, Predicate<Identity.Account> predicate) {
@@ -96,7 +104,7 @@ class IdentityVanityCommand {
             }
 
             Identity.Account account = randomAccount();
-            if (predicate.apply(account)) {
+            if (predicate.test(account)) {
                 return account;
             }
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,8 +10,6 @@ include 'nostr:nostr-nip18'
 include 'nostr:nostr-nip19'
 include 'nostr:nostr-nip21'
 include 'nostr:nostr-persona'
-//include 'nostr:nostr-proto'
-//include 'nostr:nostr-proto-json'
 include 'nostr:nostr-template'
 
 include 'nostr-relay:nostr-relay-base'

--- a/versions.gradle
+++ b/versions.gradle
@@ -20,7 +20,7 @@ ext {
     nostrProtoVersion = '0.2.0'
     springBootGradlePluginVersion = '3.4.0'
     springBootVersion = springBootGradlePluginVersion
-    springShellVersion = '3.3.3'
+    springShellVersion = '3.4.0'
     protobufGradleVersion = '0.9.4'
 }
 

--- a/versions.gradle
+++ b/versions.gradle
@@ -18,7 +18,7 @@ ext {
     checkstyleVersion = '10.3.4'
     findsecbugsPluginVersion = '1.12.0'
     nostrProtoVersion = '0.2.0'
-    springBootGradlePluginVersion = '3.4.0'
+    springBootGradlePluginVersion = '3.4.2'
     springBootVersion = springBootGradlePluginVersion
     springShellVersion = '3.4.0'
     protobufGradleVersion = '0.9.4'


### PR DESCRIPTION
```shell
nostr:>identity-vanity --npub-suffix r
{
  "privateKey" : "5c65257f15f012596ac7f8ab02a63ee77900d67d42d4d0b9cc4b10c090e6b84d",
  "publicKey" : "96b7c3db3b5c3fd3b132fcbf4319aea3a61d2a5fbbe8dd4a5c3e735be2d5df43",
  "nsec" : "nsec1t3jj2lc47qf9j6k8lz4s9f37uausp4nagt2dpwwvfvgvpy8xhpxs7gfpus",
  "npub" : "npub1j6mu8kemtsla8vfjljl5xxdw5wnp62jlh05d6jju8ee4hck4maps6a8u2r"
}
```