### PR TITLE
build(docker): update demente to v0.2.0

### DIFF
--- a/docker/regtest/demented/docker-compose-postgres.yml
+++ b/docker/regtest/demented/docker-compose-postgres.yml
@@ -2,7 +2,7 @@
 services:
   # https://github.com/theborakompanioni/demente
   relay:
-    image: ghcr.io/theborakompanioni/demented:0.1.1@sha256:4b973e28006a579476276790fcd19a4a287d92f4b12fcc1d099ed2a3f46a1052
+    image: ghcr.io/theborakompanioni/demented:0.2.0@sha256:c8e7b0f2dc1c8c8f7d5708d85a28909632a4161d94244a3806ed5b2dd177fe7a
     restart: no
     depends_on:
       postgres:

--- a/docker/regtest/demented/docker-compose.yml
+++ b/docker/regtest/demented/docker-compose.yml
@@ -2,7 +2,7 @@
 services:
   # https://github.com/theborakompanioni/demente
   relay:
-    image: ghcr.io/theborakompanioni/demented:0.1.1@sha256:4b973e28006a579476276790fcd19a4a287d92f4b12fcc1d099ed2a3f46a1052
+    image: ghcr.io/theborakompanioni/demented:0.2.0@sha256:c8e7b0f2dc1c8c8f7d5708d85a28909632a4161d94244a3806ed5b2dd177fe7a
     restart: no
     ports:
       - "7000:8080"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated relay service image to version 0.2.0 in Docker deployment configurations for both standard and PostgreSQL setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->